### PR TITLE
Support for storing point in geo point field

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,25 @@ MapMarker::make("Location")
     ->longitude('long'),
 ```
 
+### Coordinate Field Types
+By default the field will look for `latitude` and `longitude` fields on the
+model. However, if your model uses a spatial field, you may identify the column type 
+and column name with `->fieldType('point')` and `->pointField('column_name')` methods:
+
+```php
+MapMarker::make("Location")
+    ->fieldType('point')
+    ->pointField('location'),
+```
+In order to use spatial columns in Laravel Nova, you must implement a Nova Action Resource Class in config/nova.php
+```
+  'actions' => [
+        'resource' => \GeneaLabs\NovaMapMarkerField\Nova\Actions\ActionResource::class,
+    ],
+```
+
+
+
 ### Default Settings
 You can specify default settings for zoom level, and initial map center
 coordinates. If not specified, the zoom level will default to 12; the

--- a/src/MapMarker.php
+++ b/src/MapMarker.php
@@ -15,7 +15,7 @@ class MapMarker extends Field
 
             switch ($this->meta['fieldType']) {
                 case 'point':
-                    $model->{$this->getPointField()} = utf8_encode('ST_POINTFROMTEXT("POINT(' . $result->longitude . ' ' . $result->latitude . ')", ' . $this->getSrid() . ')');
+                    $model->{$this->getPointField()} = DB::raw(utf8_encode('ST_POINTFROMTEXT("POINT(' . $result->longitude . ' ' . $result->latitude . ')", ' . $this->getSrid() . ')'));
                     break;
                 default:
                     $model->{$result->latitude_field} = $this->isNullValue($result->latitude)
@@ -142,9 +142,9 @@ class MapMarker extends Field
         return $this->withMeta([__FUNCTION__ => $provider]);
     }
 
-    public function tileSubdomains(array $arr = ['a','b','c'])
+    public function tileSubdomains(array $arr = ['a', 'b', 'c'])
     {
-        return $this->withMeta(['subdomains' => $arr ]);
+        return $this->withMeta(['subdomains' => $arr]);
     }
 
     public function searchProviderKey(string $key)
@@ -165,8 +165,8 @@ class MapMarker extends Field
         $this->value = json_encode([
             "latitude_field" => $latitudeField,
             "longitude_field" => $longitudeField,
-            "latitude" => (float) $resource->{$latitudeField},
-            "longitude" => (float) $resource->{$longitudeField},
+            "latitude" => (float)$resource->{$latitudeField},
+            "longitude" => (float)$resource->{$longitudeField},
         ]);
     }
 

--- a/src/MapMarker.php
+++ b/src/MapMarker.php
@@ -1,5 +1,6 @@
 <?php namespace GeneaLabs\NovaMapMarkerField;
 
+use Illuminate\Support\Facades\DB;
 use Laravel\Nova\Fields\Field;
 use Laravel\Nova\Http\Requests\NovaRequest;
 
@@ -12,13 +13,30 @@ class MapMarker extends Field
         if ($request->exists($requestAttribute)) {
             $result = json_decode($request->{$requestAttribute}, false);
 
-            $model->{$result->latitude_field} = $this->isNullValue($result->latitude)
-                ? null
-                : $result->latitude;
-            $model->{$result->longitude_field} = $this->isNullValue($result->longitude)
-                ? null
-                : $result->longitude;
+            switch ($this->meta['fieldType']) {
+                case 'point':
+                    $model->{$this->getPointField()} = utf8_encode('ST_POINTFROMTEXT("POINT(' . $result->longitude . ' ' . $result->latitude . ')", ' . $this->getSrid() . ')');
+                    break;
+                default:
+                    $model->{$result->latitude_field} = $this->isNullValue($result->latitude)
+                        ? null
+                        : $result->latitude;
+                    $model->{$result->longitude_field} = $this->isNullValue($result->longitude)
+                        ? null
+                        : $result->longitude;
+                    break;
+            }
         }
+    }
+
+    public function getSrid()
+    {
+        return $this->meta["srid"] ?? "4326";
+    }
+
+    public function getPointField()
+    {
+        return $this->meta["pointField"] ?? "location";
     }
 
     public function getRules(NovaRequest $request)
@@ -84,6 +102,22 @@ class MapMarker extends Field
     }
 
     public function latitude($field)
+    {
+        return $this->withMeta([__FUNCTION__ => $field]);
+    }
+
+    public function fieldType($field)
+    {
+        return $this->withMeta([__FUNCTION__ => $field]);
+    }
+
+
+    public function srid($srid)
+    {
+        return $this->withMeta([__FUNCTION__ => $srid]);
+    }
+
+    public function pointField($field)
     {
         return $this->withMeta([__FUNCTION__ => $field]);
     }

--- a/src/MapMarker.php
+++ b/src/MapMarker.php
@@ -142,9 +142,9 @@ class MapMarker extends Field
         return $this->withMeta([__FUNCTION__ => $provider]);
     }
 
-    public function tileSubdomains(array $arr = ['a', 'b', 'c'])
+    public function tileSubdomains(array $arr = ['a','b','c'])
     {
-        return $this->withMeta(['subdomains' => $arr]);
+        return $this->withMeta(['subdomains' => $arr ]);
     }
 
     public function searchProviderKey(string $key)
@@ -165,8 +165,8 @@ class MapMarker extends Field
         $this->value = json_encode([
             "latitude_field" => $latitudeField,
             "longitude_field" => $longitudeField,
-            "latitude" => (float)$resource->{$latitudeField},
-            "longitude" => (float)$resource->{$longitudeField},
+            "latitude" => (float) $resource->{$latitudeField},
+            "longitude" => (float) $resource->{$longitudeField},
         ]);
     }
 

--- a/src/MapMarker.php
+++ b/src/MapMarker.php
@@ -12,8 +12,8 @@ class MapMarker extends Field
     {
         if ($request->exists($requestAttribute)) {
             $result = json_decode($request->{$requestAttribute}, false);
-
-            switch ($this->meta['fieldType']) {
+            $fieldType = $this->meta['fieldType'] ?? 'coordinates';
+            switch ($fieldType) {
                 case 'point':
                     $model->{$this->getPointField()} = DB::raw(utf8_encode('ST_POINTFROMTEXT("POINT(' . $result->longitude . ' ' . $result->latitude . ')", ' . $this->getSrid() . ')'));
                     break;

--- a/src/Models/ActionEvent.php
+++ b/src/Models/ActionEvent.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace GeneaLabs\NovaMapMarkerField\Models;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+
+class ActionEvent extends \Laravel\Nova\Actions\ActionEvent
+{
+
+    /**
+     * Create a new action event instance for a resource update.
+     *
+     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
+     * @param  \Illuminate\Database\Eloquent\Model  $model
+     * @return \Laravel\Nova\Actions\ActionEvent
+     */
+    public static function forResourceUpdate($user, $model)
+    {
+        return new static([
+            'batch_id' => (string) Str::orderedUuid(),
+            'user_id' => $user->getAuthIdentifier(),
+            'name' => 'Update',
+            'actionable_type' => $model->getMorphClass(),
+            'actionable_id' => $model->getKey(),
+            'target_type' => $model->getMorphClass(),
+            'target_id' => $model->getKey(),
+            'model_type' => $model->getMorphClass(),
+            'model_id' => $model->getKey(),
+            'fields' => '',
+            'original' => array_intersect_key($model->toArray(), $model->getDirty()),
+            'changes' => $model->getDirty(),
+            'status' => 'finished',
+            'exception' => '',
+        ]);
+    }
+}

--- a/src/Nova/Actions/ActionResource.php
+++ b/src/Nova/Actions/ActionResource.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace GeneaLabs\NovaMapMarkerField\Nova\Actions;
+
+use App\Models\ActionEvent;
+
+class ActionResource extends \Laravel\Nova\Actions\ActionResource
+{
+    public static $model = ActionEvent::class;
+}

--- a/src/Nova/Actions/ActionResource.php
+++ b/src/Nova/Actions/ActionResource.php
@@ -2,7 +2,7 @@
 
 namespace GeneaLabs\NovaMapMarkerField\Nova\Actions;
 
-use App\Models\ActionEvent;
+use GeneaLabs\NovaMapMarkerField\Models\ActionEvent;
 
 class ActionResource extends \Laravel\Nova\Actions\ActionResource
 {


### PR DESCRIPTION
PR to fix issue referenced: https://github.com/GeneaLabs/nova-map-marker-field/issues/51

Allows the user to select field type (currently only implements 'point')
uses ST_POINTFROMTEXT which should work with MySQL, PostGIS, and other geospatial database engines
Allows the user to set a custom SRID or use a sensible default (4326)

* Implemented custom Nova Action Resource Class to manage non-UTF shape data in action_event logging.